### PR TITLE
Shell scripts unix line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+* text=auto
+
+*.as    text
+*.bat   text
+*.java  text
+*.md    text
+*.sh    text eol=lf
+*.xml   text
+
+*.class  binary
+*.jar    binary

--- a/src/bin/.gitattributes
+++ b/src/bin/.gitattributes
@@ -1,0 +1,1 @@
+ascsh  text eol=lf

--- a/src/bin/ascsh
+++ b/src/bin/ascsh
@@ -26,4 +26,4 @@ fi
 
 VMARGS="-Xmx512m -Dsun.io.useCanonCaches=false "
 
-java $VMARGS $SETUP_SH_VMARGS -Dflexlib="$AIR_SDK_HOME/frameworks" -cp ${AIR_SDK_HOME}/lib;${AIR_SDK_HOME}/lib/compiler.jar ascsh_cmd "$@"
+java $VMARGS $SETUP_SH_VMARGS -Dflexlib="$AIR_SDK_HOME/frameworks" -cp "${AIR_SDK_HOME}/lib;${AIR_SDK_HOME}/lib/compiler.jar" ascsh_cmd "$@"

--- a/src/bin/ascsh
+++ b/src/bin/ascsh
@@ -26,4 +26,4 @@ fi
 
 VMARGS="-Xmx512m -Dsun.io.useCanonCaches=false "
 
-java $VMARGS $SETUP_SH_VMARGS -Dflexlib="$AIR_SDK_HOME/frameworks" -cp ${AIR_SDK_HOME}/lib:${AIR_SDK_HOME}/lib/compiler.jar ascsh_cmd "$@"
+java $VMARGS $SETUP_SH_VMARGS -Dflexlib="$AIR_SDK_HOME/frameworks" -cp ${AIR_SDK_HOME}/lib;${AIR_SDK_HOME}/lib/compiler.jar ascsh_cmd "$@"

--- a/src/bin/ascshd
+++ b/src/bin/ascshd
@@ -26,7 +26,7 @@ if (args[0]=='killall') then
 end
 
 $hostname = 'localhost'
-$ascsh_bin = ENV["AIR_HOME"]+"/bin/ascsh"
+$ascsh_bin = ENV["AIR_SDK_HOME"].gsub('\\', '/')+"/bin/ascsh"
 
 class Server
   ASCSH_PROMPT = "(ascsh) "

--- a/src/bin/ascshd.bat
+++ b/src/bin/ascshd.bat
@@ -1,0 +1,7 @@
+@echo off
+
+setlocal
+
+if "x%AIR_SDK_HOME%"=="x"  (set AIR_SDK_HOME=%~dp0..) else echo Using AIR SDK: %AIR_SDK_HOME%
+
+@ruby "%AIR_SDK_HOME%\bin\ascshd" %*


### PR DESCRIPTION
Added gitattributes - use mostly auto CRLF mode, but force LF for shell scripts (.sh files and ascsh) in particular. UNIX shell can't handle CRLF in scripts, Ruby seems to be ok so I didn't force LF for ascshd.

Second change is a fix - ascsh script didn't work due to a typo - `:` in java classpath option, should be `;`.
